### PR TITLE
rename `unstable_getServerSession` to `getServerSession`

### DIFF
--- a/pages/api/mapstory/index.ts
+++ b/pages/api/mapstory/index.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import * as z from 'zod'
-import { unstable_getServerSession } from 'next-auth/next'
+import { getServerSession } from 'next-auth/next'
 
 import { db } from '@/src/lib/db'
 import { authOptions } from '@/src/lib/auth'
@@ -12,7 +12,7 @@ import { generateSlug } from '@/src/lib/slug'
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'POST') {
     try {
-      const session = await unstable_getServerSession(req, res, authOptions)
+      const session = await getServerSession(req, res, authOptions)
       const user = session?.user
 
       const body = req.body

--- a/pages/api/users/[userId].ts
+++ b/pages/api/users/[userId].ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import * as z from 'zod'
-import { unstable_getServerSession } from 'next-auth/next'
+import { getServerSession } from 'next-auth/next'
 
 import { db } from '@/src/lib/db'
 import { userNameSchema } from '@/src/lib/validations/user'
@@ -11,7 +11,7 @@ import { withMethods } from '@/src/lib/apiMiddlewares/withMethods'
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'PATCH') {
     try {
-      const session = await unstable_getServerSession(req, res, authOptions)
+      const session = await getServerSession(req, res, authOptions)
       const user = session?.user
 
       const body = req.body

--- a/src/lib/apiMiddlewares/withAuthentication.ts
+++ b/src/lib/apiMiddlewares/withAuthentication.ts
@@ -1,11 +1,11 @@
 import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next'
-import { unstable_getServerSession } from 'next-auth/next'
+import { getServerSession } from 'next-auth/next'
 
 import { authOptions } from '@/src/lib/auth'
 
 export function withAuthentication(handler: NextApiHandler) {
   return async function (req: NextApiRequest, res: NextApiResponse) {
-    const session = await unstable_getServerSession(req, res, authOptions)
+    const session = await getServerSession(req, res, authOptions)
 
     if (!session) {
       return res.status(403).end()

--- a/src/lib/apiMiddlewares/withCurrentUser.ts
+++ b/src/lib/apiMiddlewares/withCurrentUser.ts
@@ -1,5 +1,5 @@
 import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next'
-import { unstable_getServerSession } from 'next-auth/next'
+import { getServerSession } from 'next-auth/next'
 import * as z from 'zod'
 
 import { authOptions } from '@/src/lib/auth'
@@ -14,7 +14,7 @@ export function withCurrentUser(handler: NextApiHandler) {
       const query = await schema.parse(req.query)
 
       // Check if the user has access to this user.
-      const session = await unstable_getServerSession(req, res, authOptions)
+      const session = await getServerSession(req, res, authOptions)
 
       if (query.userId !== session?.user.id) {
         return res.status(403).end()

--- a/src/lib/apiMiddlewares/withMapstory.ts
+++ b/src/lib/apiMiddlewares/withMapstory.ts
@@ -1,5 +1,5 @@
 import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next'
-import { unstable_getServerSession } from 'next-auth/next'
+import { getServerSession } from 'next-auth/next'
 import * as z from 'zod'
 
 import { authOptions } from '@/src/lib/auth'
@@ -15,7 +15,7 @@ export function withMapstory(handler: NextApiHandler) {
       const query = await schema.parse(req.query)
 
       // Check if the user has access to this mapstory.
-      const session = await unstable_getServerSession(req, res, authOptions)
+      const session = await getServerSession(req, res, authOptions)
       const count = await db.story.count({
         where: {
           id: query.storyId,

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,9 +1,9 @@
-import { unstable_getServerSession } from 'next-auth/next'
+import { getServerSession } from 'next-auth/next'
 
 import { authOptions } from '@/src/lib/auth'
 
 export async function getSession() {
-  return await unstable_getServerSession(authOptions)
+  return await getServerSession(authOptions)
 }
 
 export async function getCurrentUser() {


### PR DESCRIPTION
`unstable_getServerSession` was renamed to `getServerSession`: https://next-auth.js.org/configuration/nextjs#unstable_getserversession