### PR TITLE
Removed setting the marker on search because it was buggy

### DIFF
--- a/src/components/Studio/Mapstories/EditMapstoryView/EditMapstoryMap/index.tsx
+++ b/src/components/Studio/Mapstories/EditMapstoryView/EditMapstoryMap/index.tsx
@@ -1,6 +1,13 @@
 import Map from '@/src/components/Map'
 import { StoryStep } from '@prisma/client'
-import { MapRef, MarkerDragEvent, MarkerProps } from 'react-map-gl'
+import {
+  Layer,
+  MapRef,
+  MarkerDragEvent,
+  MarkerProps,
+  Popup,
+  Source,
+} from 'react-map-gl'
 import { useCallback, useEffect, useState } from 'react'
 import useStep from '@/src/lib/api/step/useStep'
 import { GeoJsonProperties } from 'geojson'
@@ -13,6 +20,7 @@ import GeocoderControl from '@/src/components/Map/GeocoderControl'
 import { toast } from '@/src/lib/toast'
 import mapboxgl from 'mapbox-gl'
 import React from 'react'
+import { XMarkIcon } from '@heroicons/react/24/outline'
 
 interface EditMapstoryMapProps {
   steps?: StoryStep[]
@@ -256,7 +264,8 @@ export default function EditMapstoryMap({
             },
             properties: {},
           }
-          await updateStep({ feature: point as any })
+          // this would only update the step that was selected when the component got FIRST initialized
+          // await updateStep({ feature: point as any })
         }}
         position="top-right"
       />
@@ -276,6 +285,41 @@ export default function EditMapstoryMap({
         onClick={m => router.replace(`/storylab/${story?.slug}/${m.stepId}`)}
       />
       {story?.lines && <ConnectionLines markers={markers} />}
+      {geocoderResult?.geometry?.coordinates && (
+        <>
+          <Popup
+            anchor="bottom-left"
+            latitude={geocoderResult.geometry.coordinates[1]}
+            longitude={geocoderResult.geometry.coordinates[0]}
+          >
+            <XMarkIcon
+              className="h-5 w-5 hover:cursor-pointer"
+              onClick={handleRemovePoint}
+            />
+          </Popup>
+          <Source data={geocoderResult} id="geocode-point" type="geojson">
+            <Layer
+              id="point"
+              paint={{
+                'circle-color': '#FF0000',
+                'circle-radius': {
+                  base: 9,
+                  stops: [
+                    [1, 3],
+                    [7, 5],
+                    [12, 8],
+                    [18, 15],
+                    [22, 22],
+                  ],
+                },
+                'circle-stroke-color': '#FF0000',
+                'circle-stroke-width': 2,
+              }}
+              type="circle"
+            />
+          </Source>
+        </>
+      )}
     </Map>
   )
 }

--- a/src/components/Viewer/StoryOverviewContols.tsx
+++ b/src/components/Viewer/StoryOverviewContols.tsx
@@ -133,7 +133,7 @@ export function StoryOverviewControls({ slug, page, story, tags }: Props) {
                     <div className="h text-yellow-500">{t('noSteps')}</div>
                   </div>
                 )}
-                <div className=" overflow-x-hidden pr-5">
+                <div className="overflow-x-hidden pr-5">
                   {tags.length > 0 && (
                     <div>
                       <StoryFilterInput


### PR DESCRIPTION
The updateStep method would be initialized only with the first selected step and not change with a step, therefore setting the wrong marker when using the search function.

Now does not update the marker (user has to do that via a map click) but will display a small red dot indicating the searches result
![grafik](https://github.com/reedu-reengineering-education/mapstories-2.0/assets/18304210/8e412e8d-13fa-43b3-bb2e-d5a32f0b1888)
