### PR TITLE
Feat: 383 duplicate stories

### DIFF
--- a/pages/api/mapstory/[storyId]/copy/index.ts
+++ b/pages/api/mapstory/[storyId]/copy/index.ts
@@ -17,7 +17,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       // find the story first and then duplicate it
       const session = await getServerSession(req, res, authOptions)
       const user = session?.user
-
+      
       const story = await db.story.findFirst({
         where: {
           OR: [{ id: storyId }, { slug: storyId }],
@@ -53,6 +53,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       })
 
       if (story?.steps?.length && story?.steps?.length > 0) {
+        let index = 0
         for (const step of story.steps) {
           const newStep = await db.storyStep.create({
             data: {
@@ -69,7 +70,15 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
               },
             },
           })
+          // Assign firstStepId
+          // if (index === 0) {
+          //   await db.story.update({
+          //     where: { id: storyCopy.id },
+          //     data: { firstStepId: newStep.id },
+          //   })
 
+          //   index++
+          // }
           // Get all slide contents for the given story step id
           const slideContents = await db.slideContent.findMany({
             where: {
@@ -77,7 +86,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
             },
           })
 
-          // Duplicate slide contents and assign them to the new step
+          // Copy slide contents and assign them to the new step
           slideContents.forEach(async (item) => {
             let newMedia = null
             const { type, content, position, mediaId, suggestionId } = item

--- a/pages/api/mapstory/[storyId]/copy/index.ts
+++ b/pages/api/mapstory/[storyId]/copy/index.ts
@@ -85,25 +85,18 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
           })
 
           // Copy slide contents and assign them to the new step
-          slideContents.forEach(async (item) => {
+          slideContents.forEach(async ({ type, content, position, mediaId, suggestionId }) => {
             let newMedia = null
-            const { type, content, position, mediaId, suggestionId } = item
+
             if (mediaId) {
-              const { name, size, url, altText, caption, source} = await db.media.findFirst({
+              const { name, size, url, altText, caption, source } = await db.media.findFirst({
                 where: {
                   id: mediaId,
                 }
               })
 
               newMedia = await db.media.create({
-                data: {
-                  name,
-                  size,
-                  url, 
-                  altText,
-                  caption,
-                  source
-                },
+                data: { name, size, url, altText, caption, source },
               })
             }
             await db.slideContent.create({

--- a/pages/api/mapstory/[storyId]/copy/index.ts
+++ b/pages/api/mapstory/[storyId]/copy/index.ts
@@ -41,12 +41,10 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
         res.status(401).end()
       }
       // create copy of the mapstory
-      const visibility = req.body.visibility
-      const ownerId = req.body.ownerId as string
       const storyCopy = await db.story.create({
         data: {
-          ownerId,
-          visibility,
+          ownerId: req.body.ownerId,
+          visibility: req.body.visibility,
           slug: await generateSlug(payload.name),
           ...payload
         },

--- a/pages/api/mapstory/[storyId]/copy/index.ts
+++ b/pages/api/mapstory/[storyId]/copy/index.ts
@@ -137,7 +137,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
             return
           }
 
-          let newFirstStepId = await createStep(firstStep, firstStep?.storyId ?? null)
+          newFirstStepId = await createStep(firstStep, firstStep?.storyId ?? null)
         }
         // create copy of the story
         const storyCopy = await transaction.story.create({

--- a/pages/api/mapstory/[storyId]/duplicate/index.ts
+++ b/pages/api/mapstory/[storyId]/duplicate/index.ts
@@ -78,13 +78,24 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
           })
 
           // Duplicate slide contents and assign them to the new step
-          slideContents.forEach(async ({ type, content, position, mediaId, suggestionId }) => {
+          slideContents.forEach(async (item) => {
             let newMedia = null
-            if (type === 'IMAGE') {
+            const { type, content, position, mediaId, suggestionId } = item
+            if (mediaId) {
+              const { name, size, url, altText, caption, source} = await db.media.findFirst({
+                where: {
+                  id: mediaId,
+                }
+              })
+
               newMedia = await db.media.create({
                 data: {
-                  url: content,
-                  name: content,
+                  name,
+                  size,
+                  url, 
+                  altText,
+                  caption,
+                  source
                 },
               })
             }
@@ -103,6 +114,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       }
 
       res.status(200).json(storyCopy)
+      res.end()
     } catch (error) {
       console.log(error)
       res.status(500).end()

--- a/src/app/i18n/locales/de/settingsModal.json
+++ b/src/app/i18n/locales/de/settingsModal.json
@@ -27,5 +27,6 @@
   "copying": "Kopiere...",
   "community": "Community-Modus",
   "on": "An",
-  "off": "Aus"
+  "off": "Aus",
+  "duplicateSotryPrefix": "Kopie von"
 }

--- a/src/app/i18n/locales/en/settingsModal.json
+++ b/src/app/i18n/locales/en/settingsModal.json
@@ -27,5 +27,6 @@
   "copying": "Copying...",
   "community": "Community",
   "on": "On",
-  "off": "Off"
+  "off": "Off",
+  "duplicateSotryPrefix": "Copy of"
 }

--- a/src/app/i18n/locales/es/settingsModal.json
+++ b/src/app/i18n/locales/es/settingsModal.json
@@ -25,5 +25,6 @@
   "copying": "Copiado...",
   "community": "Comunidad-Modus",
   "on": "Activo",
-  "off": "Apagado"
+  "off": "Apagado",
+  "duplicateSotryPrefix": "Copia de"
 }

--- a/src/app/i18n/locales/fr/settingsModal.json
+++ b/src/app/i18n/locales/fr/settingsModal.json
@@ -25,5 +25,6 @@
   "copying": "Copier...",
   "community": "Communauté",
   "on": "Activé",
-  "off": "Désactivé"
+  "off": "Désactivé",
+  "duplicateSotryPrefix": "Copie de"
 }

--- a/src/components/Studio/Mapstories/CopyModal.tsx
+++ b/src/components/Studio/Mapstories/CopyModal.tsx
@@ -44,7 +44,12 @@ export default function CopyModal({ storyId, storyName }: Props) {
     setLoading(true)
 
     try {
-      await copyStory({ ...story, name: data.name})
+      await copyStory({ 
+        ...story, 
+        name: data.name,
+        author: story?.author || '',
+        description: story?.description || ''
+      })
 
       toast({
         title: t('settingsModal:copied'),

--- a/src/components/Studio/Mapstories/CopyModal.tsx
+++ b/src/components/Studio/Mapstories/CopyModal.tsx
@@ -10,6 +10,7 @@ import { useState } from 'react'
 import { useTranslation } from '@/src/app/i18n/client'
 import { useBoundStore } from '@/src/lib/store/store'
 import { useForm } from 'react-hook-form'
+import { useRouter } from 'next/navigation'
 
 import * as z from 'zod'
 import { duplicateMapstorySchema } from '@/src/lib/validations/mapstory' 
@@ -36,6 +37,7 @@ export default function CopyModal({ storyId, storyName }: Props) {
 
   const [modalOpen, setModalOpen] = useState(false)
   const [loading, setLoading] = useState(false)
+  const router = useRouter()
 
   async function duplicateStory(data: FormData) {
     setLoading(true)
@@ -48,12 +50,13 @@ export default function CopyModal({ storyId, storyName }: Props) {
         },
         body: JSON.stringify({ name: data.name }),
       })
-
+      
       toast({
         title: t('settingsModal:copied'),
         message: t('settingsModal:copiedMessage'),
         type: 'success',
       })
+      router.refresh()
     } catch (e) {
       toast({
         title: t('settingsModal:somethingWrong'),

--- a/src/components/Studio/Mapstories/CopyModal.tsx
+++ b/src/components/Studio/Mapstories/CopyModal.tsx
@@ -56,6 +56,8 @@ export default function CopyModal({ storyId, storyName }: Props) {
         message: t('settingsModal:copiedMessage'),
         type: 'success',
       })
+
+      setModalOpen(false)
       router.refresh()
     } catch (e) {
       toast({
@@ -78,19 +80,19 @@ export default function CopyModal({ storyId, storyName }: Props) {
         {t('settingsModal:copy')}
       </Button>
       <Modal
-        onClose={() => setModalOpen(false)}
+        onOpenChange={setModalOpen}
         open={modalOpen}
         title={t('settingsModal:copy')}
       >
         <form onSubmit={handleSubmit(duplicateStory)}>
           <Modal.Content>
-            <p className="pb-4 pt-2">{t('settingsModal:youWantCopy')}</p>
             <InputLabel>Name</InputLabel>
             <Input
               errors={errors.name}
               size={100}
               {...register('name')}
             />
+            <p className="pb-4 pt-2">{t('settingsModal:youWantCopy')}</p>
           </Modal.Content>
           <Modal.Footer>
             <div className="flex flex-row justify-between">

--- a/src/components/Studio/Mapstories/CopyModal.tsx
+++ b/src/components/Studio/Mapstories/CopyModal.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from '@/src/app/i18n/client'
 import { useBoundStore } from '@/src/lib/store/store'
 import { useForm } from 'react-hook-form'
 import { useRouter } from 'next/navigation'
+import useStory from '@/src/lib/api/story/useStory'
 
 import * as z from 'zod'
 import { duplicateMapstorySchema } from '@/src/lib/validations/mapstory' 
@@ -27,14 +28,14 @@ export default function CopyModal({ storyId, storyName }: Props) {
   const { t } = useTranslation(lng, ['settingsModal'])
   const name = `${t('settingsModal:duplicateSotryPrefix')} ${storyName}`
   const {
-      handleSubmit,
-      register,
-      formState: { errors }
-    } = useForm<FormData>({
-      resolver: zodResolver(duplicateMapstorySchema),
-      defaultValues: { name }
-    })
-
+    handleSubmit,
+    register,
+    formState: { errors }
+  } = useForm<FormData>({
+    resolver: zodResolver(duplicateMapstorySchema),
+    defaultValues: { name }
+  })
+  const { story, copyStory } = useStory(storyId)
   const [modalOpen, setModalOpen] = useState(false)
   const [loading, setLoading] = useState(false)
   const router = useRouter()
@@ -43,13 +44,7 @@ export default function CopyModal({ storyId, storyName }: Props) {
     setLoading(true)
 
     try {
-      await fetch(`/api/mapstory/${storyId}/duplicate`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ name: data.name }),
-      })
+      await copyStory({ ...story, name: data.name})
       
       toast({
         title: t('settingsModal:copied'),

--- a/src/components/Studio/Mapstories/CopyModal.tsx
+++ b/src/components/Studio/Mapstories/CopyModal.tsx
@@ -14,10 +14,10 @@ import { useRouter } from 'next/navigation'
 import useStory from '@/src/lib/api/story/useStory'
 
 import * as z from 'zod'
-import { duplicateMapstorySchema } from '@/src/lib/validations/mapstory' 
+import { copyMapstorySchema } from '@/src/lib/validations/mapstory' 
 import { zodResolver } from '@hookform/resolvers/zod'
 
-type FormData = z.infer<typeof duplicateMapstorySchema>
+type FormData = z.infer<typeof copyMapstorySchema>
 type Props = {
   storyId: string,
   storyName: string | null 
@@ -32,7 +32,7 @@ export default function CopyModal({ storyId, storyName }: Props) {
     register,
     formState: { errors }
   } = useForm<FormData>({
-    resolver: zodResolver(duplicateMapstorySchema),
+    resolver: zodResolver(copyMapstorySchema),
     defaultValues: { name }
   })
   const { story, copyStory } = useStory(storyId)
@@ -40,12 +40,12 @@ export default function CopyModal({ storyId, storyName }: Props) {
   const [loading, setLoading] = useState(false)
   const router = useRouter()
 
-  async function duplicateStory(data: FormData) {
+  async function onCopyStory(data: FormData) {
     setLoading(true)
 
     try {
       await copyStory({ ...story, name: data.name})
-      
+
       toast({
         title: t('settingsModal:copied'),
         message: t('settingsModal:copiedMessage'),
@@ -79,7 +79,7 @@ export default function CopyModal({ storyId, storyName }: Props) {
         open={modalOpen}
         title={t('settingsModal:copy')}
       >
-        <form onSubmit={handleSubmit(duplicateStory)}>
+        <form onSubmit={handleSubmit(onCopyStory)}>
           <Modal.Content>
             <InputLabel>Name</InputLabel>
             <Input

--- a/src/components/Studio/Mapstories/CopyModal.tsx
+++ b/src/components/Studio/Mapstories/CopyModal.tsx
@@ -3,41 +3,52 @@
 import { Button } from '@/src/components/Elements/Button'
 import { Modal } from '@/src/components/Modal'
 import { DocumentDuplicateIcon } from '@heroicons/react/24/outline'
+import { Input, InputLabel } from '../../Elements/Input'
+import { toast } from '@/src/lib/toast'
+
 import { useState } from 'react'
 import { useTranslation } from '@/src/app/i18n/client'
 import { useBoundStore } from '@/src/lib/store/store'
-import { toast } from '@/src/lib/toast'
+import { useForm } from 'react-hook-form'
 
-export default function CopyModal({ storyId }: { storyId: string }) {
+import * as z from 'zod'
+import { duplicateMapstorySchema } from '@/src/lib/validations/mapstory' 
+import { zodResolver } from '@hookform/resolvers/zod'
+
+type FormData = z.infer<typeof duplicateMapstorySchema>
+type Props = {
+  storyId: string,
+  storyName: string | null 
+}
+
+export default function CopyModal({ storyId, storyName }: Props) {
   const lng = useBoundStore(state => state.language)
   const { t } = useTranslation(lng, ['settingsModal'])
+  const name = `${t('settingsModal:duplicateSotryPrefix')} ${storyName}`
+  const {
+      handleSubmit,
+      register,
+      formState: { errors }
+    } = useForm<FormData>({
+      resolver: zodResolver(duplicateMapstorySchema),
+      defaultValues: { name }
+    })
 
   const [modalOpen, setModalOpen] = useState(false)
   const [loading, setLoading] = useState(false)
 
-  const link = `${window.location.origin}/gallery/story/${storyId}/start`
+  async function duplicateStory(data: FormData) {
+    setLoading(true)
 
-  const copyToClipboard = async () => {
-    await navigator.clipboard.writeText(link)
-  }
-  const duplicateStory = async () => {
     try {
-      setLoading(true)
-
-      const mapstoryCopy = await fetch(`/api/mapstory/${storyId}/duplicate`, {
+      await fetch(`/api/mapstory/${storyId}/duplicate`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
+        body: JSON.stringify({ name: data.name }),
       })
-      const mapstoryCopyJson = await mapstoryCopy.json()
 
-      const newMappstory = await fetch(`/api/mapstory/${mapstoryCopyJson.id}`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      })
       toast({
         title: t('settingsModal:copied'),
         message: t('settingsModal:copiedMessage'),
@@ -49,14 +60,14 @@ export default function CopyModal({ storyId }: { storyId: string }) {
         message: t('settingsModal:somethingWrong'),
         type: 'error',
       })
+    } finally {
+      setLoading(false)
     }
-    setLoading(false)
   }
 
   return (
     <>
       <Button
-        className=""
         onClick={() => setModalOpen(true)}
         startIcon={<DocumentDuplicateIcon className="w-5" />}
         variant={'inverse'}
@@ -68,19 +79,27 @@ export default function CopyModal({ storyId }: { storyId: string }) {
         open={modalOpen}
         title={t('settingsModal:copy')}
       >
-        <Modal.Content>
-          <p className="pb-4 pt-2">{t('settingsModal:youWantCopy')}</p>
-        </Modal.Content>
-        <Modal.Footer>
-          <div className="flex flex-row justify-between">
-            <Button onClick={() => setModalOpen(false)} variant={'inverse'}>
-              {t('settingsModal:cancel')}
-            </Button>
-            <Button disabled={loading} onClick={() => duplicateStory()}>
-              {loading ? t('settingsModal:copying') : t('settingsModal:copy')}
-            </Button>
-          </div>
-        </Modal.Footer>
+        <form onSubmit={handleSubmit(duplicateStory)}>
+          <Modal.Content>
+            <p className="pb-4 pt-2">{t('settingsModal:youWantCopy')}</p>
+            <InputLabel>Name</InputLabel>
+            <Input
+              errors={errors.name}
+              size={100}
+              {...register('name')}
+            />
+          </Modal.Content>
+          <Modal.Footer>
+            <div className="flex flex-row justify-between">
+              <Button onClick={() => setModalOpen(false)} variant={'inverse'}>
+                {t('settingsModal:cancel')}
+              </Button>
+              <Button disabled={loading} type="submit">
+                {loading ? t('settingsModal:copying') : t('settingsModal:copy')}
+              </Button>
+            </div>
+          </Modal.Footer>
+        </form>
       </Modal>
     </>
   )

--- a/src/components/Studio/Mapstories/MapstoryCard.tsx
+++ b/src/components/Studio/Mapstories/MapstoryCard.tsx
@@ -14,6 +14,8 @@ import ShareModal from './ShareModal'
 import EmbedModal from './EmbedModal'
 import { EyeIcon, PencilIcon } from '@heroicons/react/24/outline'
 import { StoryBadge } from './StoryBadge'
+import CopyModal from './CopyModal'
+
 type Props = {
   mapstory: Story
 }
@@ -45,7 +47,7 @@ export function MapstoryCard({ mapstory }: Props) {
               </Button>
             </Link>
             {/* <SettingsModal storyId={mapstory.id} /> */}
-            {/* <CopyModal storyId={mapstory.id} /> */}
+            <CopyModal storyId={mapstory.id} storyName={mapstory.name} />
             <ShareModal storyId={mapstory.id} />
             <EmbedModal storyId={mapstory.slug} />
             {(mapstory as any).stepSuggestions.length > 0 && (

--- a/src/lib/api/story/copyStory.ts
+++ b/src/lib/api/story/copyStory.ts
@@ -1,0 +1,11 @@
+import axios from '@/src/lib/axios'
+import { APIError } from '@/types'
+import { Story } from '@prisma/client'
+import { AxiosResponse } from 'axios'
+
+export const copyStory = (storyId: string, props: Partial<Story>) => {
+  return axios.post<typeof props, AxiosResponse<Story, APIError>>(
+    `/api/mapstory/${storyId}/duplicate`,
+    props,
+  )
+}

--- a/src/lib/api/story/copyStory.ts
+++ b/src/lib/api/story/copyStory.ts
@@ -5,7 +5,7 @@ import { AxiosResponse } from 'axios'
 
 export const copyStory = (storyId: string, props: Partial<Story>) => {
   return axios.post<typeof props, AxiosResponse<Story, APIError>>(
-    `/api/mapstory/${storyId}/duplicate`,
+    `/api/mapstory/${storyId}/copy`,
     props,
   )
 }

--- a/src/lib/api/story/useStory.ts
+++ b/src/lib/api/story/useStory.ts
@@ -13,6 +13,7 @@ import { deleteStory } from './deleteStory'
 import { deleteStoryStep } from './deleteStoryStep'
 import { reorderStorySteps } from './reorderSteps'
 import { updateStory } from './updateStory'
+import { copyStory } from './copyStory'
 import { createStepSuggestion } from './createStepSuggestion'
 import { deleteStepSuggestion } from './deleteStepSuggestion'
 
@@ -38,6 +39,11 @@ const useStory = (storyId: string) => {
   const APIUpdateStory = async (story: Partial<Story>) => {
     const updateStoryRequest = updateStory(storyId, story)
     return await mutation(updateStoryRequest)
+  }
+
+  const APICopyStory = async (story: Partial<Story>) => {
+    const copyStoryRequest = copyStory(storyId, story)
+    return await mutation(copyStoryRequest)
   }
 
   const APIDeleteStory = async () => {
@@ -122,6 +128,7 @@ const useStory = (storyId: string) => {
     mutate,
     createStory: APICreateStory,
     updateStory: APIUpdateStory,
+    copyStory: APICopyStory,
     deleteStory: APIDeleteStory,
     reorderStorySteps: APIReorderStorySteps,
     createStoryStep: APICreateStoryStep,

--- a/src/lib/validations/mapstory.ts
+++ b/src/lib/validations/mapstory.ts
@@ -13,7 +13,7 @@ export const updateMapstorySchema = z.object({
   author: z.string(),
   mode: z.enum([StoryMode.NORMAL, StoryMode.TIMELINE]),
   visibility: z.enum(['PRIVATE', 'PUBLIC']),
-  themeId: z.string().optional(),
+  themeId: z.string().nullable().optional(),
   lines: z.boolean(),
   community: z.boolean(),
 })

--- a/src/lib/validations/mapstory.ts
+++ b/src/lib/validations/mapstory.ts
@@ -17,3 +17,7 @@ export const updateMapstorySchema = z.object({
   lines: z.boolean(),
   community: z.boolean(),
 })
+
+export const duplicateMapstorySchema = z.object({
+  name: z.string().min(3).max(100),
+})

--- a/src/lib/validations/mapstory.ts
+++ b/src/lib/validations/mapstory.ts
@@ -18,6 +18,6 @@ export const updateMapstorySchema = z.object({
   community: z.boolean(),
 })
 
-export const duplicateMapstorySchema = z.object({
+export const copyMapstorySchema = z.object({
   name: z.string().min(3).max(100),
 })


### PR DESCRIPTION
Closes #383 

**Completed**

- Used existing <CopyModal /> component as a starting point.
- Added input field to allow editing story name copy with length validation and added corresponding translations. As an inspiration I used similar functionality in Google Docs.
- Renamed existing /duplicate endpoint for copying over a story to /copy and reworked logic.
- Added necessary types/definitions.

**Open questions**
- I haven't figured out how to use suggestions, so I couldn't verify that copying works well for them.
- Question about themeId verification (see comments below)

**UI**
![image](https://github.com/user-attachments/assets/2ef02856-0ead-434e-98c8-cfc105ed6916)
![image](https://github.com/user-attachments/assets/938015ed-dbc6-4251-80a1-26bf8eba03dc)

**Test instructions**
One should be able to copy existing story with default/updated name.
From my side I verified that the following scenarios work as expected:
- copy over timeline story with several steps
- copy over regular story with several steps